### PR TITLE
Migrating to sessionStorage from localStorage

### DIFF
--- a/src/app/Conversor.js
+++ b/src/app/Conversor.js
@@ -41,7 +41,7 @@ class Conversor extends React.Component {
         } else if (response.json) {
           return response.json();
         } else {
-          localStorage.removeItem('TS_API');
+          sessionStorage.removeItem('TS_API');
           throw new Error('Error: could not find a valid data source');
         }
       })
@@ -60,8 +60,8 @@ class Conversor extends React.Component {
           });
         };
 
-        if (!localStorage.getItem('TS_API')) {
-          localStorage.setItem('TS_API', JSON.stringify(data));
+        if (!sessionStorage.getItem('TS_API')) {
+          sessionStorage.setItem('TS_API', JSON.stringify(data));
         }
 
         return new Promise((resolve, reject) => {

--- a/src/app/FetchData.js
+++ b/src/app/FetchData.js
@@ -6,10 +6,12 @@ const fetchData = function () {
 };
 
 const fetchDataIfNeeded = function () {
-  if (localStorage.getItem('TS_API')) {
+  const sessionStorageData = sessionStorage.getItem('TS_API');
+
+  if (sessionStorageData) {
     return new Promise((resolve, reject) => {
       setTimeout(() => {
-        const data = JSON.parse(localStorage.getItem('TS_API'));
+        const data = JSON.parse(sessionStorageData);
         return resolve(data);
       }, 100);
     });


### PR DESCRIPTION
We currently have an issue as per reported [here](https://github.com/iorrah/transfersmart/issues/12) whereby the app does not posses the ability of comparing the date since the last time a request was made and the current point at time. 

For this reason, data stored on the client side ends up not being updated even when the API is actually providing recalculated currency rates.

A per the MDN [document](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) on the matter, the `sessionStorage` API provides an advantage that might help the presented issue to be addressed: data stored in the user's browser is removed when the window or tab that data is attached to is finished but is kept in case of multiple page reloads.

We are therefore going to A/B test this new approach and see if it has positive impacts on the performance of the application.